### PR TITLE
Fix UnicodeDecodeError on Windows

### DIFF
--- a/pandoc_static_katex.py
+++ b/pandoc_static_katex.py
@@ -37,6 +37,7 @@ def katex(key, value, format, meta):
         text=True,
         capture_output=True,
         check=True,
+        encoding='utf-8',
     )
     return pandocfilters.RawInline(
         'html',

--- a/test_cases/math.md
+++ b/test_cases/math.md
@@ -5,7 +5,7 @@
 This is inline $\log(\frac{1}{2})$ and this is display, and also wrong:
 
 $$
-\int_{-\infty}^{+\infty}\Lamda(x)dx
+\int_{-\infty}^{+\infty}\Lambda(x)dx
 $$
 
 Complicated things should look OK inline $\frac{1}{1 + \frac{1}{2}}$.


### PR DESCRIPTION
While  91dcb72  fixes the `FileNotFoundError` #2 on Windows, the filter now crashes on a `UnicodeDecodeError` on Windows when non-ASCII characters (e.g. a Λ) are present in the output stream. This is caused by Python defaulting to cp1252 when no encoding is specified. So the fix is simple: add an explicit encoding!